### PR TITLE
[상품 옵션] 기능 구현 - 옵션 세트 및 옵션 추가/삭제

### DIFF
--- a/src/components/atoms/ButtonAppend/index.jsx
+++ b/src/components/atoms/ButtonAppend/index.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as S from './style';
 
-export function ButtonAppend({ width, height, content }) {
+export function ButtonAppend({ width, height, content, onClick }) {
   return (
-    <S.Wrapper type="button" width={width} height={height}>
+    <S.Wrapper type="button" width={width} height={height} onClick={onClick}>
       {content}
     </S.Wrapper>
   );
@@ -14,9 +14,11 @@ ButtonAppend.propTypes = {
   width: PropTypes.string,
   height: PropTypes.string,
   content: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
 };
 
 ButtonAppend.defaultProps = {
   width: null,
   height: null,
+  onClick: null,
 };

--- a/src/components/atoms/ButtonAppend/style.jsx
+++ b/src/components/atoms/ButtonAppend/style.jsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 export const Wrapper = styled.button`
   width: ${(props) => props.width};
   height: ${(props) => props.height};
-  /* margin: 12px; */
   border: 1px solid #4609ad;
   border-radius: 4px;
   background-color: #fff;

--- a/src/components/atoms/ButtonTheme/style.jsx
+++ b/src/components/atoms/ButtonTheme/style.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const Wrapper = styled.button`
+export const Wrapper = styled.div`
   position: relative;
   display: flex;
   justify-content: center;

--- a/src/components/atoms/Checkbox/index.jsx
+++ b/src/components/atoms/Checkbox/index.jsx
@@ -10,7 +10,7 @@ export function Checkbox({ theme, onCheck }) {
   return (
     <S.Container>
       <label htmlFor={id}>
-        <input id={id} type="checkbox" onClick={() => onCheck(key)} checked={isChecked} />
+        <input id={id} type="checkbox" checked={isChecked} onChange={() => onCheck(key)} />
         <span>{name}</span>
       </label>
     </S.Container>

--- a/src/components/atoms/Tag/index.jsx
+++ b/src/components/atoms/Tag/index.jsx
@@ -13,7 +13,8 @@ export function Tag({ tag, isSelectedFilter, onCheck }) {
 }
 
 Tag.propTypes = {
-  tag: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  tag: PropTypes.object.isRequired,
   isSelectedFilter: PropTypes.bool,
   onCheck: PropTypes.func.isRequired,
 };

--- a/src/components/molecules/ProductOptionDetail/index.jsx
+++ b/src/components/molecules/ProductOptionDetail/index.jsx
@@ -1,41 +1,65 @@
-import React from 'react';
-import { ButtonDelete } from 'components';
+import React, { useState } from 'react';
+import { nanoid } from 'nanoid';
+import { ButtonAppend, ButtonDelete } from 'components';
 import * as S from './style';
 
 export function ProductOptionDetail() {
+  const [options, setOptions] = useState([{ id: nanoid() }]);
+
   return (
-    <S.Wrapper>
-      <div className="delete-option">
-        <ButtonDelete width="60px" height="32px" />
-      </div>
+    <>
+      {options.map((option) => (
+        <S.Wrapper key={option.id}>
+          <div className="delete-option">
+            <ButtonDelete
+              width="60px"
+              height="32px"
+              onClick={() => {
+                setOptions(options.filter((element) => element.id !== option.id));
+              }}
+            />
+          </div>
 
-      <div className="option-name">
-        <input type="text" placeholder="옵션명을 입력해 주세요. (필수)" />
-      </div>
+          <div className="option-name">
+            <input type="text" placeholder="옵션명을 입력해 주세요. (필수)" />
+          </div>
 
-      <div className="option-info">
-        <input className="price" type="text" placeholder="상품 정상가 (필수)" />원
-        <span>
-          할인율: <b>38%</b>
-        </span>
-        <input className="price" type="text" placeholder="상품 판매가 (필수)" />원
-        <input className="stock" type="text" placeholder="재고 (필수)" />개
-        <select name="tax">
-          <option value="non-taxable">비과세</option>
-          <option value="taxable">과세</option>
-        </select>
-      </div>
+          <div className="option-info">
+            <input className="price" type="text" placeholder="상품 정상가 (필수)" />원
+            <span>
+              할인율: <b>38%</b>
+            </span>
+            <input className="price" type="text" placeholder="상품 판매가 (필수)" />원
+            <input className="stock" type="text" placeholder="재고 (필수)" />개
+            <select name="tax">
+              <option value="non-taxable">비과세</option>
+              <option value="taxable">과세</option>
+            </select>
+          </div>
 
-      <div className="suboption-info">
-        <span>└</span>
-        <input className="name" type="text" placeholder="추가 옵션명 (필수)" />
-        <input className="price" type="text" placeholder="추가 옵션 정상가 (필수)" />원
-        <ButtonDelete width="60px" height="42px" />
-      </div>
+          <div className="suboption-info">
+            <span>└</span>
+            <input className="name" type="text" placeholder="추가 옵션명 (필수)" />
+            <input className="price" type="text" placeholder="추가 옵션 정상가 (필수)" />원
+            <ButtonDelete width="60px" height="42px" />
+          </div>
 
-      <div className="append-suboption">
-        <button type="button">╋</button> 추가 옵션 상품 추가
+          <div className="append-suboption">
+            <button type="button">╋</button> 추가 옵션 상품 추가
+          </div>
+        </S.Wrapper>
+      ))}
+
+      <div className="append-option">
+        <ButtonAppend
+          width="100%"
+          height="54px"
+          content="+ 옵션 추가"
+          onClick={() => {
+            setOptions([...options, { id: nanoid() }]);
+          }}
+        />
       </div>
-    </S.Wrapper>
+    </>
   );
 }

--- a/src/components/molecules/ProductOptionImage/style.jsx
+++ b/src/components/molecules/ProductOptionImage/style.jsx
@@ -7,11 +7,11 @@ export const Wrapper = styled.section`
 
   height: 240px;
   border: 1px solid #ddd;
-  background-color: #dedede;
+  background-color: #eee;
   background-position: center;
   background-size: cover;
 
   label {
-    background-color: rgba(222, 222, 222, 0.5);
+    background-color: rgba(238, 238, 238, 0.5);
   }
 `;

--- a/src/components/molecules/ThemeSelected/index.jsx
+++ b/src/components/molecules/ThemeSelected/index.jsx
@@ -9,7 +9,6 @@ export function ThemeSelected({ checkedLists, onCheck }) {
       {checkedLists.length ? (
         checkedLists.map((checkedList) => (
           <ButtonTheme
-            type="button"
             key={checkedList.key}
             text={checkedList.name}
             onCheck={() => onCheck(checkedList.key)}

--- a/src/components/organisms/ProductOption/index.jsx
+++ b/src/components/organisms/ProductOption/index.jsx
@@ -5,7 +5,6 @@ import * as S from './style';
 
 export function ProductOption() {
   const [optionSets, setOptionSets] = useState([{ id: nanoid() }]);
-  const [options, setOptions] = useState([{ id: nanoid() }]);
 
   return (
     <S.Container>
@@ -35,21 +34,7 @@ export function ProductOption() {
           </div>
 
           <ProductOptionImage />
-
-          {options.map((option) => (
-            <ProductOptionDetail key={option.id} />
-          ))}
-
-          <div className="append-option">
-            <ButtonAppend
-              width="100%"
-              height="54px"
-              content="+ 옵션 추가"
-              onClick={() => {
-                setOptions([...options, { id: nanoid() }]);
-              }}
-            />
-          </div>
+          <ProductOptionDetail />
         </S.Wrapper>
       ))}
     </S.Container>

--- a/src/components/organisms/ProductOption/index.jsx
+++ b/src/components/organisms/ProductOption/index.jsx
@@ -24,7 +24,13 @@ export function ProductOption() {
       {optionSets.map((optionSet) => (
         <S.Wrapper key={optionSet.id}>
           <div className="delete-set">
-            <ButtonDelete width="70px" height="35px" />
+            <ButtonDelete
+              width="70px"
+              height="35px"
+              onClick={() => {
+                setOptionSets(optionSets.filter((element) => element.id !== optionSet.id));
+              }}
+            />
           </div>
 
           <ProductOptionImage />

--- a/src/components/organisms/ProductOption/index.jsx
+++ b/src/components/organisms/ProductOption/index.jsx
@@ -4,17 +4,21 @@ import * as S from './style';
 
 export function ProductOption() {
   return (
-    <S.Wrapper>
-      <div className="delete-set">
-        <ButtonDelete width="70px" height="35px" />
-      </div>
+    <S.Container>
+      <span className="default-text">옵션세트를 추가하여 옵션을 구성해 주세요.</span>
 
-      <ProductOptionImage />
-      <ProductOptionDetail />
+      <S.Wrapper>
+        <div className="delete-set">
+          <ButtonDelete width="70px" height="35px" />
+        </div>
 
-      <div className="append-option">
-        <ButtonAppend width="100%" height="54px" content="+ 옵션 추가" />
-      </div>
-    </S.Wrapper>
+        <ProductOptionImage />
+        <ProductOptionDetail />
+
+        <div className="append-option">
+          <ButtonAppend width="100%" height="54px" content="+ 옵션 추가" />
+        </div>
+      </S.Wrapper>
+    </S.Container>
   );
 }

--- a/src/components/organisms/ProductOption/index.jsx
+++ b/src/components/organisms/ProductOption/index.jsx
@@ -1,28 +1,40 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { nanoid } from 'nanoid';
 import { ButtonAppend, ButtonDelete, ProductOptionImage, ProductOptionDetail } from 'components';
 import * as S from './style';
 
 export function ProductOption() {
+  const [optionSets, setOptionSets] = useState([{ id: nanoid() }]);
+
   return (
     <S.Container>
-      <span className="default-text">옵션세트를 추가하여 옵션을 구성해 주세요.</span>
+      <span className="default-text">옵션 세트를 추가하여 옵션을 구성해 주세요.</span>
 
       <div className="append-set">
-        <ButtonAppend width="130px" height="40px" content="+ 옵션 세트 추가" />
+        <ButtonAppend
+          width="130px"
+          height="40px"
+          content="+ 옵션 세트 추가"
+          onClick={() => {
+            setOptionSets([...optionSets, { id: nanoid() }]);
+          }}
+        />
       </div>
 
-      <S.Wrapper>
-        <div className="delete-set">
-          <ButtonDelete width="70px" height="35px" />
-        </div>
+      {optionSets.map((optionSet) => (
+        <S.Wrapper key={optionSet.id}>
+          <div className="delete-set">
+            <ButtonDelete width="70px" height="35px" />
+          </div>
 
-        <ProductOptionImage />
-        <ProductOptionDetail />
+          <ProductOptionImage />
+          <ProductOptionDetail />
 
-        <div className="append-option">
-          <ButtonAppend width="100%" height="54px" content="+ 옵션 추가" />
-        </div>
-      </S.Wrapper>
+          <div className="append-option">
+            <ButtonAppend width="100%" height="54px" content="+ 옵션 추가" />
+          </div>
+        </S.Wrapper>
+      ))}
     </S.Container>
   );
 }

--- a/src/components/organisms/ProductOption/index.jsx
+++ b/src/components/organisms/ProductOption/index.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
-import { ButtonDelete, ProductOptionImage, ProductOptionDetail, ButtonAppend } from 'components';
+import { ButtonAppend, ButtonDelete, ProductOptionImage, ProductOptionDetail } from 'components';
 import * as S from './style';
 
 export function ProductOption() {
   return (
     <S.Container>
       <span className="default-text">옵션세트를 추가하여 옵션을 구성해 주세요.</span>
+
+      <div className="append-set">
+        <ButtonAppend width="130px" height="40px" content="+ 옵션 세트 추가" />
+      </div>
 
       <S.Wrapper>
         <div className="delete-set">

--- a/src/components/organisms/ProductOption/index.jsx
+++ b/src/components/organisms/ProductOption/index.jsx
@@ -5,6 +5,7 @@ import * as S from './style';
 
 export function ProductOption() {
   const [optionSets, setOptionSets] = useState([{ id: nanoid() }]);
+  const [options, setOptions] = useState([{ id: nanoid() }]);
 
   return (
     <S.Container>
@@ -34,10 +35,20 @@ export function ProductOption() {
           </div>
 
           <ProductOptionImage />
-          <ProductOptionDetail />
+
+          {options.map((option) => (
+            <ProductOptionDetail key={option.id} />
+          ))}
 
           <div className="append-option">
-            <ButtonAppend width="100%" height="54px" content="+ 옵션 추가" />
+            <ButtonAppend
+              width="100%"
+              height="54px"
+              content="+ 옵션 추가"
+              onClick={() => {
+                setOptions([...options, { id: nanoid() }]);
+              }}
+            />
           </div>
         </S.Wrapper>
       ))}

--- a/src/components/organisms/ProductOption/style.jsx
+++ b/src/components/organisms/ProductOption/style.jsx
@@ -6,6 +6,7 @@ export const Container = styled.div`
   flex-direction: column;
 
   min-height: 750px;
+  padding-top: 32px;
   background-color: rgba(238, 238, 238, 0.5);
 
   .append-set {
@@ -29,7 +30,7 @@ export const Wrapper = styled.article`
   gap: 12px;
 
   width: 820px;
-  margin: 72px 40px 40px;
+  margin: 40px 30px;
   border: 1px solid #ddd;
   padding: 14px;
   background-color: #fff;

--- a/src/components/organisms/ProductOption/style.jsx
+++ b/src/components/organisms/ProductOption/style.jsx
@@ -8,6 +8,12 @@ export const Container = styled.div`
   min-height: 750px;
   background-color: rgba(238, 238, 238, 0.5);
 
+  .append-set {
+    position: absolute;
+    top: -41px;
+    right: 0;
+  }
+
   .default-text {
     position: absolute;
     top: 250px;

--- a/src/components/organisms/ProductOption/style.jsx
+++ b/src/components/organisms/ProductOption/style.jsx
@@ -9,17 +9,18 @@ export const Container = styled.div`
   padding-top: 32px;
   background-color: rgba(238, 238, 238, 0.5);
 
-  .append-set {
-    position: absolute;
-    top: -41px;
-    right: 0;
-  }
-
   .default-text {
     position: absolute;
     top: 250px;
     left: 50%;
     transform: translate(-50%, -50%);
+    font-size: 18px;
+  }
+
+  .append-set {
+    position: absolute;
+    top: -41px;
+    right: 0;
   }
 `;
 

--- a/src/components/organisms/ProductOption/style.jsx
+++ b/src/components/organisms/ProductOption/style.jsx
@@ -1,5 +1,21 @@
 import styled from 'styled-components';
 
+export const Container = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+
+  min-height: 750px;
+  background-color: rgba(238, 238, 238, 0.5);
+
+  .default-text {
+    position: absolute;
+    top: 250px;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+`;
+
 export const Wrapper = styled.article`
   position: relative;
   display: flex;
@@ -10,6 +26,7 @@ export const Wrapper = styled.article`
   margin: 72px 40px 40px;
   border: 1px solid #ddd;
   padding: 14px;
+  background-color: #fff;
 
   .delete-set {
     position: absolute;

--- a/src/components/organisms/SaveBar/style.jsx
+++ b/src/components/organisms/SaveBar/style.jsx
@@ -5,7 +5,7 @@ export const Container = styled.div`
   justify-content: space-between;
   align-items: center;
 
-  width: 940px;
+  width: 920px;
   border: 1px solid #ddd;
   padding: 10px 20px;
 `;

--- a/src/components/organisms/Theme/index.jsx
+++ b/src/components/organisms/Theme/index.jsx
@@ -9,6 +9,7 @@ export function Theme({ formStates, handleChange }) {
       category.key === key ? { ...category, isChecked: !category.isChecked } : category,
     );
     const checked = edit.filter((category) => category.isChecked);
+
     handleChange({ themes: edit, checkedLists: checked });
   };
 

--- a/src/components/templates/Category/style.jsx
+++ b/src/components/templates/Category/style.jsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const Wrapper = styled.section`
   position: relative;
-  width: 900px;
+  width: 880px;
   margin: 30px 20px;
   border: 1px solid #ddd;
 

--- a/src/pages/ProductRegister/index.jsx
+++ b/src/pages/ProductRegister/index.jsx
@@ -22,13 +22,9 @@ import { INITIAL_STATES, SET_EXPIRATION, SET_SALES, SET_DELIVERY } from 'constan
 import * as S from './style';
 
 export function ProductRegister() {
-  const [formStates, setFormStates] = useState(INITIAL_STATES);
   const [openModal, setOpenModal] = useState(false);
   const [modalText, setModalText] = useState('');
-
-  const handleChange = (newStates) => {
-    setFormStates({ ...formStates, ...newStates });
-  };
+  const [formStates, setFormStates] = useState(INITIAL_STATES);
 
   const validateSubmit = () => {
     const message = setError(formStates);
@@ -36,6 +32,10 @@ export function ProductRegister() {
       setModalText(message);
       setOpenModal(true);
     }
+  };
+
+  const handleChange = (newStates) => {
+    setFormStates({ ...formStates, ...newStates });
   };
 
   return (
@@ -68,7 +68,7 @@ export function ProductRegister() {
           <GoodsInformation handleChange={handleChange} />
         </Item>
         <Item title="상품 썸네일">
-          <ImageAppender />
+          <ImageAppender isMulti={false} />
         </Item>
         <Item title="상품 대표 이미지">
           <ImageAppender isMulti />

--- a/src/pages/ProductRegister/index.jsx
+++ b/src/pages/ProductRegister/index.jsx
@@ -15,7 +15,6 @@ import {
   SaveBar,
   Theme,
   InputDatePeriod,
-  ButtonAppend,
   ButtonSwitch,
 } from 'components';
 import { setError, validateStartBeforeEnd } from 'utils';
@@ -81,10 +80,6 @@ export function ProductRegister() {
 
       {/* 10~12 */}
       <Category title="상품 옵션*">
-        <div className="append-set">
-          <ButtonAppend width="130px" height="40px" content="+ 옵션 세트 추가" />
-        </div>
-
         <ProductOption />
       </Category>
 

--- a/src/pages/ProductRegister/style.jsx
+++ b/src/pages/ProductRegister/style.jsx
@@ -1,9 +1,3 @@
 import styled from 'styled-components';
 
-export const Container = styled.main`
-  .append-set {
-    position: absolute;
-    top: 0;
-    right: 0;
-  }
-`;
+export const Container = styled.main``;


### PR DESCRIPTION
## 구현 화면

<img width="1280" alt="week1_22" src="https://user-images.githubusercontent.com/72926450/151711276-bc6068e0-746a-4abb-8626-2333c1757a9b.png">
<img width="1280" alt="week1_23" src="https://user-images.githubusercontent.com/72926450/151711218-67c26eb2-9437-4351-b325-7042ad5cd4ce.png">

## 구현 범위

완성된 상품 옵션 영역의 레이아웃 내에 구현되어야 할 **기본적인 추가/삭제 기능을 구현**했습니다. (10, 11, 12번 항목 전반에 걸쳐 해당)

- `pages` **ProductRegister** (상품 등록)
  - `templates` **Category** (상품 옵션)
  - `organisms` **ProductOption** - 상품의 옵션 세트의 추가/삭제를 다루는 부분
    - `molecules` **ProductOptionDetail** - 상품의 옵션의 추가/삭제를 다루는 부분
    - `molecules` **ProductOptionImage**  (상품의 이미지 파일을 첨부 및 미리보기 가능)

## 질문 및 특이사항

> ☝️브라우저에서 프로젝트를 실행시켰을 때(Localhost), 콘솔 창에서 출력된 경고들이 몇 가지 있어
**[이번 PR](https://github.com/team-tyranno/wanted-ADM-PRODUCT-ADD/commit/f55348e9bfc9efd2de1b64f93779893c5cafaebc)에서 해당 경고들의 원인을 파악하여 해결**하였습니다. _(중요한 로직을 건드려야 하는 문제는 없었음!)_