### PR TITLE
[상품 옵션] 기능 구현 - 옵션 내 서브옵션 추가/삭제

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -22,6 +22,7 @@ export { ButtonRadioGroup } from 'components/molecules/ButtonRadioGroup';
 export { InputDatePeriod } from 'components/molecules/InputDatePeriod';
 export { InputLabelGroup } from 'components/molecules/InputLabelGroup';
 export { ProductOptionDetail } from 'components/molecules/ProductOptionDetail';
+export { ProductOptionForm } from 'components/molecules/ProductOptionForm';
 export { ProductOptionImage } from 'components/molecules/ProductOptionImage';
 export { TagSelect } from 'components/molecules/TagSelect';
 export { TagSelected } from 'components/molecules/TagSelected';

--- a/src/components/molecules/ProductOptionDetail/index.jsx
+++ b/src/components/molecules/ProductOptionDetail/index.jsx
@@ -1,64 +1,31 @@
 import React, { useState } from 'react';
 import { nanoid } from 'nanoid';
-import { ButtonAppend, ButtonDelete } from 'components';
-import * as S from './style';
+import { ButtonDelete } from 'components';
 
 export function ProductOptionDetail() {
-  const [options, setOptions] = useState([{ id: nanoid() }]);
+  const [suboptions, setSuboptions] = useState([]);
 
   return (
     <>
-      {options.map((option) => (
-        <S.Wrapper key={option.id}>
-          <div className="delete-option">
-            <ButtonDelete
-              width="60px"
-              height="32px"
-              onClick={() => {
-                setOptions(options.filter((element) => element.id !== option.id));
-              }}
-            />
-          </div>
-
-          <div className="option-name">
-            <input type="text" placeholder="옵션명을 입력해 주세요. (필수)" />
-          </div>
-
-          <div className="option-info">
-            <input className="price" type="text" placeholder="상품 정상가 (필수)" />원
-            <span>
-              할인율: <b>38%</b>
-            </span>
-            <input className="price" type="text" placeholder="상품 판매가 (필수)" />원
-            <input className="stock" type="text" placeholder="재고 (필수)" />개
-            <select name="tax">
-              <option value="non-taxable">비과세</option>
-              <option value="taxable">과세</option>
-            </select>
-          </div>
-
-          <div className="suboption-info">
-            <span>└</span>
-            <input className="name" type="text" placeholder="추가 옵션명 (필수)" />
-            <input className="price" type="text" placeholder="추가 옵션 정상가 (필수)" />원
-            <ButtonDelete width="60px" height="42px" />
-          </div>
-
-          <div className="append-suboption">
-            <button type="button">╋</button> 추가 옵션 상품 추가
-          </div>
-        </S.Wrapper>
+      {suboptions.map((suboption) => (
+        <div key={suboption.id} className="suboption-info">
+          <span>└</span>
+          <input className="name" type="text" placeholder="추가 옵션명 (필수)" />
+          <input className="price" type="text" placeholder="추가 옵션 정상가 (필수)" />원
+          <ButtonDelete width="60px" height="42px" />
+        </div>
       ))}
 
-      <div className="append-option">
-        <ButtonAppend
-          width="100%"
-          height="54px"
-          content="+ 옵션 추가"
+      <div className="append-suboption">
+        <button
+          type="button"
           onClick={() => {
-            setOptions([...options, { id: nanoid() }]);
+            setSuboptions([...suboptions, { id: nanoid() }]);
           }}
-        />
+        >
+          ╋
+        </button>
+        추가 옵션 상품 추가
       </div>
     </>
   );

--- a/src/components/molecules/ProductOptionDetail/index.jsx
+++ b/src/components/molecules/ProductOptionDetail/index.jsx
@@ -12,7 +12,13 @@ export function ProductOptionDetail() {
           <span>└</span>
           <input className="name" type="text" placeholder="추가 옵션명 (필수)" />
           <input className="price" type="text" placeholder="추가 옵션 정상가 (필수)" />원
-          <ButtonDelete width="60px" height="42px" />
+          <ButtonDelete
+            width="60px"
+            height="42px"
+            onClick={() => {
+              setSuboptions(suboptions.filter((element) => element.id !== suboption.id));
+            }}
+          />
         </div>
       ))}
 

--- a/src/components/molecules/ProductOptionForm/index.jsx
+++ b/src/components/molecules/ProductOptionForm/index.jsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { nanoid } from 'nanoid';
+import { ButtonAppend, ButtonDelete, ProductOptionDetail } from 'components';
+import * as S from './style';
+
+export function ProductOptionForm() {
+  const [options, setOptions] = useState([{ id: nanoid() }]);
+
+  return (
+    <>
+      {options.map((option) => (
+        <S.Wrapper key={option.id}>
+          <div className="delete-option">
+            <ButtonDelete
+              width="60px"
+              height="32px"
+              onClick={() => {
+                setOptions(options.filter((element) => element.id !== option.id));
+              }}
+            />
+          </div>
+
+          <div className="option-name">
+            <input type="text" placeholder="옵션명을 입력해 주세요. (필수)" />
+          </div>
+
+          <div className="option-info">
+            <input className="price" type="text" placeholder="상품 정상가 (필수)" />원
+            <span>
+              할인율: <b>38%</b>
+            </span>
+            <input className="price" type="text" placeholder="상품 판매가 (필수)" />원
+            <input className="stock" type="text" placeholder="재고 (필수)" />개
+            <select name="tax">
+              <option value="non-taxable">비과세</option>
+              <option value="taxable">과세</option>
+            </select>
+          </div>
+
+          <ProductOptionDetail />
+        </S.Wrapper>
+      ))}
+
+      <div className="append-option">
+        <ButtonAppend
+          width="100%"
+          height="54px"
+          content="+ 옵션 추가"
+          onClick={() => {
+            setOptions([...options, { id: nanoid() }]);
+          }}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/molecules/ProductOptionForm/style.jsx
+++ b/src/components/molecules/ProductOptionForm/style.jsx
@@ -78,7 +78,7 @@ export const Wrapper = styled.section`
 
       input {
         height: 42px;
-        margin-right: -20px;
+        margin-right: -25px;
         border: 1px solid #ddd;
         border-radius: 4px;
         padding-left: 12px;
@@ -98,7 +98,6 @@ export const Wrapper = styled.section`
       display: flex;
       align-items: center;
       margin-right: auto;
-      cursor: pointer;
 
       button {
         width: 27px;

--- a/src/components/organisms/ProductOption/index.jsx
+++ b/src/components/organisms/ProductOption/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { nanoid } from 'nanoid';
-import { ButtonAppend, ButtonDelete, ProductOptionImage, ProductOptionDetail } from 'components';
+import { ButtonAppend, ButtonDelete, ProductOptionImage, ProductOptionForm } from 'components';
 import * as S from './style';
 
 export function ProductOption() {
@@ -12,8 +12,8 @@ export function ProductOption() {
 
       <div className="append-set">
         <ButtonAppend
-          width="130px"
-          height="40px"
+          width="140px"
+          height="49px"
           content="+ 옵션 세트 추가"
           onClick={() => {
             setOptionSets([...optionSets, { id: nanoid() }]);
@@ -34,7 +34,7 @@ export function ProductOption() {
           </div>
 
           <ProductOptionImage />
-          <ProductOptionDetail />
+          <ProductOptionForm />
         </S.Wrapper>
       ))}
     </S.Container>

--- a/src/components/organisms/ProductOption/style.jsx
+++ b/src/components/organisms/ProductOption/style.jsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 
-export const Container = styled.div`
+export const Container = styled.form`
   position: relative;
   display: flex;
   flex-direction: column;
 
-  min-height: 750px;
+  min-height: 700px;
   padding-top: 32px;
   background-color: rgba(238, 238, 238, 0.5);
 
@@ -19,7 +19,7 @@ export const Container = styled.div`
 
   .append-set {
     position: absolute;
-    top: -41px;
+    top: -49px;
     right: 0;
   }
 `;


### PR DESCRIPTION
## 구현 범위

완성된 상품 옵션 영역의 레이아웃 내에 구현되어야 할 **추가적인 추가/삭제 기능을 구현**했습니다. (11번 항목 위주로 해당)

- `pages` **ProductRegister** (상품 등록)
  - `templates` **Category** (상품 옵션)
  - `organisms` **ProductOption** - 상품의 옵션 세트의 추가/삭제를 다루는 부분
    - `molecules` **ProductOptionImage**  (상품의 이미지 파일을 첨부 및 미리보기 가능)
    - `molecules` **ProductOptionForm** - 상품의 옵션의 추가/삭제를 다루는 부분
      - `molecules` **ProductOptionDetail** - 상품의 서브옵션의 추가/삭제를 다루는 부분